### PR TITLE
Have been using it with streamly 0.7.0

### DIFF
--- a/evdev.cabal
+++ b/evdev.cabal
@@ -34,7 +34,7 @@ library
                        hinotify             >= 0.4 && < 0.5,
                        posix-paths          >= 0.2.1 && < 0.3,
                        rawfilepath          >= 0.2.4 && < 0.3,
-                       streamly             >= 0.6.1 && < 0.7,
+                       streamly             >= 0.6.1 && < 0.8,
   build-tool-depends:  c2hs:c2hs
   default-language:    Haskell2010
   default-extensions:  FlexibleContexts


### PR DESCRIPTION
Code works with streamly 0.7.0, I've been testing it for a new pet project https://github.com/bneijt/rfid-kodi-control and I have not been able to find any problem with it yet.
Please consider raising the version limit.