### PR TITLE
Byofd

### DIFF
--- a/evdev/src/Evdev.hs
+++ b/evdev/src/Evdev.hs
@@ -6,6 +6,7 @@ module Evdev (
     Device,
     newDevice,
     nextEvent,
+    nextEventMay,
     evdevDir,
     -- ** Properties
     deviceName,
@@ -137,6 +138,10 @@ ungrabDevice = grabDevice' LL.LibevdevUngrab
 nextEvent :: Device -> IO Event
 nextEvent dev =
     fromCEvent <$> cErrCall "nextEvent" dev (LL.nextEvent (cDevice dev) (convertFlags defaultReadFlags))
+
+nextEventMay :: Device -> IO (Maybe Event)
+nextEventMay dev =
+    (fmap fromCEvent) <$> cErrCall "nextEventMay" dev (LL.nextEventMay (cDevice dev) (convertFlags defaultReadFlags))
 
 fromCEvent :: LL.CEvent -> Event
 fromCEvent (LL.CEvent t c v time) = Event (fromCEventData (t,c,v)) $ fromCTimeVal time

--- a/evdev/src/Evdev.hs
+++ b/evdev/src/Evdev.hs
@@ -53,7 +53,7 @@ module Evdev (
 
 import Control.Arrow ((&&&))
 import Control.Monad (filterM, join)
-import Data.ByteString.Char8 (ByteString)
+import Data.ByteString.Char8 (ByteString, pack)
 import Data.Int (Int32)
 import Data.List.Extra (enumerate)
 import Data.Map ((!?), Map)
@@ -70,9 +70,7 @@ import Foreign.C (CUInt)
 import System.Posix.Process (getProcessID)
 import System.Posix.Files (readSymbolicLink)
 import System.Posix.ByteString (Fd, RawFilePath)
-import System.Posix.Files (readSymbolicLink)
 import System.Posix.IO.ByteString (OpenMode (ReadOnly), defaultFileFlags, openFd)
-import System.Posix.Process (getProcessID)
 
 import qualified Evdev.LowLevel as LL
 import Evdev.Codes
@@ -221,7 +219,7 @@ newDeviceFromFd fd = do
     dev <- cErrCall "newDeviceFromFd" () $ LL.newDeviceFromFd fd
     pid <- getProcessID
     path <- readSymbolicLink $ "/proc/" <> show pid <> "/fd/" <> show fd
-    return $ Device{cDevice = dev, devicePath = BS.pack path}
+    return $ Device{cDevice = dev, devicePath = pack path}
 
 -- | The usual directory containing devices (/"\/dev\/input"/).
 evdevDir :: RawFilePath

--- a/evdev/src/Evdev.hs
+++ b/evdev/src/Evdev.hs
@@ -78,7 +78,7 @@ import Util
 -- stores path that was originally used, as it seems impossible to recover this later
 -- We don't allow the user to access the underlying low-level C device.
 -- | An input device.
-data Device = Device { cDevice :: LL.Device, devicePath :: String }
+data Device = Device { cDevice :: LL.Device, devicePath :: ByteString }
 
 
 instance Show Device where
@@ -213,7 +213,7 @@ newDeviceFromFd fd = do
   dev <- cErrCall "newDeviceFromFd" () $ LL.newDeviceFromFd fd
   pid <- getProcessID
   path <- readSymbolicLink $ "/proc/" <> show pid <> "/fd/" <> show fd
-  return $ Device { cDevice = dev, devicePath = path }
+  return $ Device { cDevice = dev, devicePath = BS.pack path }
 
 -- | The usual directory containing devices (/"\/dev\/input"/).
 evdevDir :: RawFilePath

--- a/evdev/src/Evdev.hs
+++ b/evdev/src/Evdev.hs
@@ -77,6 +77,8 @@ import Util
 -- We don't allow the user to access the underlying low-level C device.
 -- | An input device.
 data Device = Device { cDevice :: LL.Device, devicePath :: RawFilePath }
+
+
 instance Show Device where
     show = show . devicePath
 
@@ -200,15 +202,15 @@ toCTimeVal t = LL.CTimeVal n (round $ f * 1_000_000)
 
 -- | Create a device from a valid path - usually /\/dev\/input\/eventX/ for some /X/.
 newDevice :: RawFilePath -> IO Device
-newDevice path = newDeviceFromFd (Just path) =<< openFd path ReadOnly Nothing defaultFileFlags
+newDevice path = newDeviceFromFd =<< openFd path ReadOnly Nothing defaultFileFlags
 
 -- | General constructor for a Device.
--- WARNING: The resulting `Device' will have the GC close your `Fd'.
-newDeviceFromFd :: Maybe RawFilePath -> Fd -> IO Device
-newDeviceFromFd path =
-  let path' = maybe "" id path
-  -- It is probably bad manners to flip a record type.
-  in fmap (flip Device path') . cErrCall "newDeviceFromFd" path' . LL.newDeviceFromFd
+-- WARNING: The resulting `Device' will have the GC close your `Fd' with its custom finalizer.
+newDeviceFromFd :: Fd -> IO Device
+newDeviceFromFd fd = do
+  dev <- cErrCall "newDeviceFromFd" () $ LL.newDeviceFromFd fd
+  path <- join $ LL.deviceName dev
+  return $ Device { cDevice = dev, devicePath = path }
 
 -- | The usual directory containing devices (/"\/dev\/input"/).
 evdevDir :: RawFilePath

--- a/evdev/src/Evdev/LowLevel.chs
+++ b/evdev/src/Evdev/LowLevel.chs
@@ -1,7 +1,6 @@
 module Evdev.LowLevel where
 
 import Control.Monad (join)
-import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Loops (iterateWhile)
 import Data.ByteString (ByteString,packCString,useAsCString)
 import Data.Coerce (coerce)
@@ -11,7 +10,7 @@ import Foreign (Ptr,allocaBytes,mallocBytes,mallocForeignPtrBytes,newForeignPtr_
 import Foreign.C (CInt(..),CLong(..),CUInt(..),CUShort(..),CString)
 import Foreign.C.Error (Errno(Errno), eOK)
 import System.Posix.ByteString (RawFilePath)
-import System.Posix.IO.ByteString (OpenMode(ReadOnly),defaultFileFlags,openFd)
+import System.Posix.IO.ByteString (OpenMode(ReadOnly),defaultFileFlags,openFd,OpenFileFlags)
 import System.Posix.Types (Fd(Fd))
 
 import Evdev.Codes
@@ -104,6 +103,14 @@ grabDevice = libevdev_grab
 newDevice :: RawFilePath -> IO (Errno, Device)
 newDevice path = do
     fd <- openFd path ReadOnly Nothing defaultFileFlags
+    dev <- libevdev_new
+    err <- libevdev_set_fd dev fd
+    return (err, dev)
+
+-- Get access to non-blocking filedescriptors.
+newDevice' :: RawFilePath -> OpenFileFlags -> IO (Errno, Device)
+newDevice' path flags = do
+    fd <- openFd path ReadOnly Nothing flags
     dev <- libevdev_new
     err <- libevdev_set_fd dev fd
     return (err, dev)

--- a/evdev/src/Evdev/LowLevel.chs
+++ b/evdev/src/Evdev/LowLevel.chs
@@ -100,20 +100,9 @@ grabDevice = libevdev_grab
 --TODO use 'libevdev_new_from_fd' when https://github.com/haskell/c2hs/issues/236 fixed
 {#fun libevdev_new {} -> `Device' #}
 {#fun libevdev_set_fd { `Device', unFd `Fd' } -> `Errno' Errno #}
-newDevice :: RawFilePath -> IO (Errno, Device)
-newDevice path = do
-    fd <- openFd path ReadOnly Nothing defaultFileFlags
-    dev <- libevdev_new
-    err <- libevdev_set_fd dev fd
-    return (err, dev)
-
--- Get access to non-blocking filedescriptors.
-newDevice' :: RawFilePath -> OpenFileFlags -> IO (Errno, Device)
-newDevice' path flags = do
-    fd <- openFd path ReadOnly Nothing flags
-    dev <- libevdev_new
-    err <- libevdev_set_fd dev fd
-    return (err, dev)
+-- General constructor for Device
+newDeviceFromFd :: Fd -> IO (Errno, Device)
+newDeviceFromFd fd = libevdev_new >>= \dev -> (, dev) <$> libevdev_set_fd dev fd
 
 --TODO 'useAsCString' copies, which seems unnecessary due to the 'const' in the C function
 {#fun libevdev_set_name { `Device', `CString' } -> `()' #}

--- a/evdev/src/Evdev/LowLevel.chs
+++ b/evdev/src/Evdev/LowLevel.chs
@@ -63,7 +63,7 @@ data CTimeVal = CTimeVal
 {#fun libevdev_next_event { `Device', `CUInt', `Ptr ()' } -> `Errno' Errno #}
 nextEvent :: Device -> CUInt -> IO (Errno, CEvent)
 nextEvent dev flags = allocaBytes {#sizeof input_event #} $ \evPtr ->
-    (,) <$> iterateWhile (== Errno (-{#const EAGAIN #})) (libevdev_next_event dev flags evPtr)
+    (,) <$> libevdev_next_event dev flags evPtr
         <*> ( CEvent
             <$> (coerce <$> {#get input_event->type #} evPtr)
             <*> (coerce <$> {#get input_event->code #} evPtr)


### PR DESCRIPTION
Bring Your Own File Descriptor ;)

closes #8

This still needs some tweaks, and obviously I need to make sure there is agreement about the interface (and the contract with the users not to use their `Fd` after making a `Device`).  Although, to that point about gobbling the file descriptor: anything they do with an `Fd` that could fail will be wrapped in `IO`.  So, we aren't really violating any logical assumptions by destroying it, since calls to the OS about a descriptor could always fail anyway, and they cannot be treated as logical certainties.

I will add some annotations to the diffs for stuff I think is unresolved ;)