### PR TITLE
Add a failing test for deivceUniq and devicePhys

### DIFF
--- a/evdev/test/Test.hs
+++ b/evdev/test/Test.hs
@@ -42,6 +42,8 @@ smoke = testCase "Smoke" do
             Nothing -> assertFailure "Couldn't find device with correct name"
             Just d -> do
                 putMVar start ()
+                (@?= "") =<< devicePhys d
+                (@?= "") =<< deviceUniq d
                 (@?= [EvSyn, EvKey]) =<< deviceEventTypes d
                 evs' <- whileJust ((\x -> guard (x /= last evs) $> x) . eventData <$> nextEvent d) pure
                 filter (/= SyncEvent SynReport) evs' @?= init evs


### PR DESCRIPTION
Failing test for #15. Test fails with `SIGSEGV`.
```
Tests
  Smoke:       fish: Job 1, '…' terminated by signal SIGSEGV (Address boundary error)
```