### PR TITLE
Support setting the state of a LED on a device.

### DIFF
--- a/evdev/src/Evdev.hs
+++ b/evdev/src/Evdev.hs
@@ -36,6 +36,8 @@ module Evdev (
     -- * Lower-level
     newDeviceFromFd,
     nextEventMay,
+    LL.LEDValue(..),
+    setDeviceLED,
     -- ** C-style types
     -- | These correspond more directly to C's /input_event/ and /timeval/.
     -- They are used internally, but may be useful for advanced users.
@@ -253,6 +255,9 @@ deviceHasEvent dev e = LL.hasEventCode (cDevice dev) typ code
 deviceAbsAxis :: Device -> AbsoluteAxis -> IO (Maybe LL.AbsInfo)
 deviceAbsAxis dev = LL.getAbsInfo (cDevice dev) . fromEnum'
 
+-- | Set the state of a LED on a device.
+setDeviceLED :: Device -> LEDEvent -> LL.LEDValue -> IO ()
+setDeviceLED dev led val = cErrCall "setDeviceLED" dev (LL.libevdev_kernel_set_led_value (cDevice dev) led val)
 
 {- Util -}
 

--- a/evdev/src/Evdev/LowLevel.chs
+++ b/evdev/src/Evdev/LowLevel.chs
@@ -177,6 +177,12 @@ getAbsInfo dev x = withDevice dev \devPtr ->
 {#fun libevdev_enable_event_code as enableCode { `Device', `Word16', `Word16', `Ptr ()' } -> `Errno' Errno #}
 {#fun libevdev_uinput_write_event as writeEvent { `UDevice', `Word16', `Word16', `Int32' } -> `Errno' Errno #}
 
+-- | LEDs values
+{#enum define LEDValue {
+    LIBEVDEV_LED_ON as LedOn,
+    LIBEVDEV_LED_OFF as LedOff}
+    deriving (Bounded, Eq, Ord, Read, Show) #}
+{#fun libevdev_kernel_set_led_value { `Device', convertEnum `LEDEvent', `LEDValue' } -> `Errno' Errno #}
 
 {- Util -}
 


### PR DESCRIPTION
Add `setDeviceLED` to set the state of a LED on a device.