### PR TITLE
Fix `uinput-echo` example

### DIFF
--- a/evdev-examples/uinput/Main.hs
+++ b/evdev-examples/uinput/Main.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import Control.Monad
+import Data.Maybe (mapMaybe)
 
 import qualified Evdev.Codes as Codes
 import Evdev.Uinput
@@ -10,7 +11,7 @@ main = do
     dev <-
         newDevice
             "haskell-uinput-echo-example"
-            defaultDeviceOpts{keys = [Codes.KeyA .. Codes.KeyZ] ++ [Codes.Key1 .. Codes.Key0]}
+            defaultDeviceOpts{keys = mapMaybe charToEvent (['a' .. 'z'] ++ ['0'..'9'])}
     forever do
         cs <- getLine
         writeBatch dev [KeyEvent k a | Just k <- map charToEvent cs, a <- [Pressed, Released]]


### PR DESCRIPTION
In the setup of the device, the keys were initialized to

```
[Codes.KeyA .. Codes.KeyZ] ++ [Codes.Key1 .. Codes.Key0]
```

But that is incorrect: `KeyA` corresponds to value 30 and `KeyZ` corresponds to value 44; this therefore excludes keys such as `KeyB` (48) and others. This can be observed by running the example and typing `abcde`; only `ad` will be echoed back.

Perhaps the better fix would be to modify the `Enum` instance, but that might result in difficult to debug backwards incompatibility problems, so this PR simply fixes the example.