### PR TITLE
Wait for uinput device creation

### DIFF
--- a/evdev/evdev.cabal
+++ b/evdev/evdev.cabal
@@ -29,6 +29,7 @@ common common
         rawfilepath ^>= {1.0, 1.1},
         time ^>= {1.9.3, 1.10, 1.11, 1.12, 1.13, 1.14},
         unix ^>= 2.8,
+        udev,
     default-language: GHC2021
     default-extensions:
         BlockArguments

--- a/evdev/src/Evdev/Uinput.hs
+++ b/evdev/src/Evdev/Uinput.hs
@@ -32,7 +32,7 @@ import Evdev.Codes
 import qualified Evdev.LowLevel as LL
 import Util
 
-import Control.Concurrent (newEmptyMVar, putMVar, readMVar)
+import Control.Concurrent (newEmptyMVar, putMVar, readMVar, threadDelay)
 import Control.Monad.Loops (untilM_)
 import Data.Maybe (fromMaybe)
 import GHC.Event qualified as Event
@@ -112,6 +112,7 @@ newDevice name DeviceOpts{..} = do
         Just devnode -> untilM_ (pure ()) $ (== devnode) <$> readMVar mv
     Event.unregisterFd eventManager fdKey
     UDev.freeUDev udev
+    threadDelay 100000
     pure uinputDev
   where
     cec :: CErrCall a => IO a -> IO (CErrCallRes a)

--- a/evdev/src/Evdev/Uinput.hs
+++ b/evdev/src/Evdev/Uinput.hs
@@ -32,6 +32,12 @@ import Evdev.Codes
 import qualified Evdev.LowLevel as LL
 import Util
 
+import Control.Concurrent (newEmptyMVar, putMVar, readMVar)
+import Control.Monad.Loops (untilM_)
+import Data.Maybe (fromMaybe)
+import GHC.Event qualified as Event
+import System.UDev qualified as UDev
+
 -- | A `uinput` device.
 newtype Device = Device LL.UDevice
 
@@ -84,7 +90,29 @@ newDevice name DeviceOpts{..} = do
         LL.withAbsInfo absInfo $ \ptr ->
             enable ptr EvAbs [fromEnum' axis]
 
-    fmap Device $ cec $ LL.createFromDevice dev $ fromEnum' LL.UOMManaged
+    -- wait for device creation
+    mv <- newEmptyMVar
+    udev <- UDev.newUDev
+    monitor <- UDev.newFromNetlink udev UDev.UDevId
+    UDev.enableReceiving monitor
+    UDev.filterAddMatchSubsystemDevtype monitor "input" Nothing
+    UDev.enableReceiving monitor
+    fd <- UDev.getFd monitor
+    eventManager <- fromMaybe (error "not using GHC's threaded RTS") <$> Event.getSystemEventManager
+    fdKey <-
+        Event.registerFd
+            eventManager
+            (\_ _ -> traverse_ (putMVar mv) . UDev.getDevnode =<< UDev.receiveDevice monitor)
+            fd
+            Event.evtRead
+            Event.MultiShot
+    uinputDev <- fmap Device $ cec $ LL.createFromDevice dev $ fromEnum' LL.UOMManaged
+    deviceDevnode uinputDev >>= \case
+        Nothing -> pure () -- shouldn't generally happen - just return and hope for the best
+        Just devnode -> untilM_ (pure ()) $ (== devnode) <$> readMVar mv
+    Event.unregisterFd eventManager fdKey
+    UDev.freeUDev udev
+    pure uinputDev
   where
     cec :: CErrCall a => IO a -> IO (CErrCallRes a)
     cec = cErrCall "newDevice" ()


### PR DESCRIPTION
Unfortunately the principled approach in the first commit isn't enough without the arbitrary wait in the second, which possibly makes the first redundant. This can be seen with `echo 'testing' | $(cabal list-bin uinput-echo)`.

Note that on device creation we see two events in the `registerFd` callback. In these, `(UDev.getDevnode udevDev, UDev.getSyspath udevDev)` gives us (ignoring IO and errors) `(Nothing, deviceSyspath uinputDev)` then `(Just deviceDevnode, deviceSyspath uinputDev </> baseName (deviceDevnode uinputDev))`. We look for the second event, so that we know (in theory...) that initialisation has finished, and check the first element because it's simpler, though this may not be the best approach if `deviceSyspath uinputDev` is `Nothing`, e.g. on FreeBSD.

